### PR TITLE
Fix: `npm run generate` and build previews

### DIFF
--- a/content/sections/dive-deeper.json
+++ b/content/sections/dive-deeper.json
@@ -9,7 +9,7 @@
         "push_left": "off-1"
       },
       "heading": "Dive deeper",
-      "subheading": "Join our talks, instructional videos, community meetings and other events to explore them <a href=\"href=\"https://www.youtube.com/channel/UCeM5ezNgFM1Sle_gIz-KMMA\"\" target=\"_blank\">visit our Youtube channel</a>"
+      "subheading": "Join our talks, instructional videos, community meetings and other events to explore them <a href='//www.youtube.com/channel/UCeM5ezNgFM1Sle_gIz-KMMA' target='_blank'>visit our Youtube channel</a>"
     }
   },
   {


### PR DESCRIPTION
`dive-deeper.json` accidentally had a double-nesting of an href attribute like this: `href="href="...""` → which the app only caught during the HTML minification step and therefore this was not visible in development.